### PR TITLE
fix problems on Android 16

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ val allArch: Array<String> by rootProject.ext
 
 android {
     namespace = "cn.tinyhai.ban_uninstall"
-    compileSdk = 34
+    compileSdk = 36
 
     signingConfigs {
         register("release") {

--- a/app/src/main/java/cn/tinyhai/ban_uninstall/hooker/HookInjectSelf.kt
+++ b/app/src/main/java/cn/tinyhai/ban_uninstall/hooker/HookInjectSelf.kt
@@ -18,9 +18,20 @@ class HookInjectSelf {
 
     @MethodHooker(
         className = "android.app.servertransaction.LaunchActivityItem",
+        methodName = "",
+        hookType = HookType.BeforeMethod,
+        minSdkInclusive = Build.VERSION_CODES.BAKLAVA
+    )
+    fun beforeConstructors(param: XC_MethodHook.MethodHookParam) {
+        handleLaunchActivity(param)
+    }
+
+    @MethodHooker(
+        className = "android.app.servertransaction.LaunchActivityItem",
         methodName = "obtain",
         hookType = HookType.BeforeMethod,
-        minSdkInclusive = Build.VERSION_CODES.P
+        minSdkInclusive = Build.VERSION_CODES.P,
+        maxSdkExclusive = Build.VERSION_CODES.BAKLAVA
     )
     fun beforeObtain(param: XC_MethodHook.MethodHookParam) {
         handleLaunchActivity(param)

--- a/app/src/main/java/cn/tinyhai/ban_uninstall/transact/server/TransactService.kt
+++ b/app/src/main/java/cn/tinyhai/ban_uninstall/transact/server/TransactService.kt
@@ -66,11 +66,11 @@ object TransactService : ITransactor.Stub(), PkgInfoContainer {
             for (userId in userIds) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     pm.getInstalledPackages(0L, userId).list.filter {
-                        it.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM == 0
+                        it.applicationInfo!!.flags and ApplicationInfo.FLAG_SYSTEM == 0
                     }
                 } else {
                     pm.getInstalledPackages(0, userId).list.filter {
-                        it.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM == 0
+                        it.applicationInfo!!.flags and ApplicationInfo.FLAG_SYSTEM == 0
                     }
                 }.let {
                     list.addAll(it)

--- a/app/src/main/java/cn/tinyhai/ban_uninstall/vm/BannedAppViewModel.kt
+++ b/app/src/main/java/cn/tinyhai/ban_uninstall/vm/BannedAppViewModel.kt
@@ -100,10 +100,10 @@ class BannedAppViewModel : ViewModel() {
             withContext(Dispatchers.IO) {
                 val allPackages = client.packages.list
                 val appInfoList = allPackages.map {
-                    val label = it.applicationInfo.loadLabel(pm).toString()
-                    val icon = it.applicationInfo.loadIcon(pm)
-                    val packageName = it.packageName ?: it.applicationInfo.packageName
-                    val uid = it.applicationInfo.uid
+                    val label = it.applicationInfo!!.loadLabel(pm).toString()
+                    val icon = it.applicationInfo!!.loadIcon(pm)
+                    val packageName = it.packageName ?: it.applicationInfo!!.packageName
+                    val uid = it.applicationInfo!!.uid
                     AppInfo(label, icon, PkgInfo(packageName, uid / 100_000))
                 }
                 val bannedPkgInfos = client.allBannedPackages.map { PkgInfo(it) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.0"
+agp = "8.13.0"
 androidx-appcompat = "1.6.1"
 biometric = "1.2.0-alpha05"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Mar 24 15:52:18 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hook/src/main/java/cn/tinyhai/xp/hook/Hooker.kt
+++ b/hook/src/main/java/cn/tinyhai/xp/hook/Hooker.kt
@@ -76,11 +76,19 @@ interface HookerHelper {
     fun findAndHookFirst(
         clazz: Class<*>, methodName: String, callback: XC_MethodHook
     ): Unhook? {
-        val hooker = clazz.declaredMethods.firstOrNull { it.name == methodName }?.let {
-            XposedBridge.hookMethod(it, callback).also {
-                logger.verbose("hook ${clazz.canonicalName}#$methodName success")
+        val hooker = if (methodName == "") {
+            XposedBridge.hookAllConstructors(clazz, callback).also {
+                logger.verbose("hook ${clazz.canonicalName}#(all constructors) success")
+            } as Unhook?
+        } else {
+            clazz.declaredMethods.firstOrNull { it.name == methodName }?.let {
+                XposedBridge.hookMethod(it, callback).also {
+                    logger.verbose("hook ${clazz.canonicalName}#$methodName success")
+                }
             }
+
         }
+
         if (hooker == null) {
             logger.error("hook ${clazz.canonicalName}#$methodName failed !!!!!")
         }


### PR DESCRIPTION
This PR fixes problems when running on Android 16.

My test device: OnePlus 15 (ColorOS 16, Android 16)

- update `compileSdk` to 36 (Android 16 Baklava)
Updated `compileSdk` to Android 16 due to `Build.VERSION_CODES`. 
Fixed some compile errors related to incompatibility.

- fix hook on Android 16
Due to some code changes on Android 16, there is no `obtain` method in `android.app.servertransaction.LaunchActivityItem` now. The corresponding codes have been moved to the constructors of `android.app.servertransaction.LaunchActivityItem`. [reference](https://android.googlesource.com/platform/frameworks/base/+/bf6e6a269306add96de96c94156573a313cac072%5E%21)
Therefore, a hook with empty `methodName` has been added, and `Hooker.kt` also need to be modified to make an empty `methodName' being treated as constructor hooks.


修复了Android 16无法使用的问题。

测试设备：一加15 (ColorOS 16, Android 16)

- update `compileSdk` to 36 (Android 16 Baklava)
因为老版本没有Android 16的`Build.VERSION_CODES`，所以将`compileSdk`升级到了Android 16，并修复了一些升级带来的编译错误。

- fix hook on Android 16
Android 16的代码发生了变化，现在`android.app.servertransaction.LaunchActivityItem`类中没有`obtain`方法了，相关逻辑移动到了构造函数中。[参考](https://android.googlesource.com/platform/frameworks/base/+/bf6e6a269306add96de96c94156573a313cac072%5E%21)
所以我写了一个`methodName`为空字符串的hook，并修改了`Hooker.kt`，将空的`methodName`当做对构造函数进行hook。