### PR TITLE
fix: uninstall from launcher on ZUX OS 2.0/1.5 (mainly Lenovo tablets)

### DIFF
--- a/app/src/main/java/cn/tinyhai/ban_uninstall/hooker/HookSystem.kt
+++ b/app/src/main/java/cn/tinyhai/ban_uninstall/hooker/HookSystem.kt
@@ -259,7 +259,8 @@ class HookSystem(
     @MethodHooker(
         className = "com.android.server.pm.PackageManagerService",
         methodName = "deletePackageVersioned",
-        minSdkInclusive = Build.VERSION_CODES.O
+        minSdkInclusive = Build.VERSION_CODES.O,
+        hookAll = true
     )
     fun beforeDeletePackageVersioned(param: MethodHookParam) {
         handleDeletePackage(param)

--- a/hook/src/main/java/cn/tinyhai/xp/annotation/MethodHooker.kt
+++ b/hook/src/main/java/cn/tinyhai/xp/annotation/MethodHooker.kt
@@ -7,7 +7,8 @@ annotation class MethodHooker(
     val hookType: HookType = HookType.BeforeMethod,
     val className: String = "",
     val minSdkInclusive: Int = 0,
-    val maxSdkExclusive: Int = Int.MAX_VALUE
+    val maxSdkExclusive: Int = Int.MAX_VALUE,
+    val hookAll: Boolean = false
 )
 
 enum class HookType {

--- a/hook/src/main/java/cn/tinyhai/xp/hook/Hooker.kt
+++ b/hook/src/main/java/cn/tinyhai/xp/hook/Hooker.kt
@@ -79,7 +79,7 @@ interface HookerHelper {
         val hooker = if (methodName == "") {
             XposedBridge.hookAllConstructors(clazz, callback).also {
                 logger.verbose("hook ${clazz.canonicalName}#(all constructors) success")
-            } as Unhook?
+            }.firstOrNull()
         } else {
             clazz.declaredMethods.firstOrNull { it.name == methodName }?.let {
                 XposedBridge.hookMethod(it, callback).also {
@@ -103,6 +103,27 @@ interface HookerHelper {
         }.onFailure {
             logger.error(it)
         }.getOrNull()
+    }
+
+    fun MutableList<Unhook>.hookAndAddAll(
+        clazz: Class<*>,
+        methodName: String,
+        callback: XC_MethodHook
+    ) {
+        findAndHookAll(clazz, methodName, callback)?.also { addAll(it) }
+    }
+
+    fun MutableList<Unhook>.hookAndAddAll(
+        className: String,
+        classLoader: ClassLoader,
+        methodName: String,
+        callback: XC_MethodHook
+    ) {
+        runCatching {
+            findAndHookAll(classLoader.loadClass(className), methodName, callback)?.also { addAll(it) }
+        }.onFailure {
+            logger.error(it)
+        }
     }
 
     fun MutableList<Unhook>.hookAndAddFirst(

--- a/processor/src/main/java/cn/tinyhai/xp/processor/codegen/GenerateHookScope.kt
+++ b/processor/src/main/java/cn/tinyhai/xp/processor/codegen/GenerateHookScope.kt
@@ -348,9 +348,10 @@ class GenerateHookScope(
                                 scopeClassName,
                                 scopeSpec
                             )
+                            val memberName = if (info.hookAll) "hookAndAddAll" else "hookAndAddFirst"
                             addStatement(
                                 "unhooks.%N(%S, %N.%N, %S, callback)",
-                                hookHelper.member("hookAndAddFirst"),
+                                hookHelper.member(memberName),
                                 info.targetClassName,
                                 paramSpec,
                                 classLoader,

--- a/processor/src/main/java/cn/tinyhai/xp/processor/codegen/HookerInfo.kt
+++ b/processor/src/main/java/cn/tinyhai/xp/processor/codegen/HookerInfo.kt
@@ -11,5 +11,6 @@ data class HookerInfo(
     val unhookable: Boolean,
     val hookType: HookType,
     val minSdk: Int,
-    val maxSdk: Int
+    val maxSdk: Int,
+    val hookAll: Boolean
 )

--- a/processor/src/main/java/cn/tinyhai/xp/processor/parser/HookerInfoParser.kt
+++ b/processor/src/main/java/cn/tinyhai/xp/processor/parser/HookerInfoParser.kt
@@ -38,7 +38,8 @@ class HookerInfoParser(
                 unhookable = unhookable,
                 hookType = methodHooker.hookType,
                 minSdk = methodHooker.minSdkInclusive,
-                maxSdk = methodHooker.maxSdkExclusive
+                maxSdk = methodHooker.maxSdkExclusive,
+                hookAll = methodHooker.hookAll
             )
         }.toList()
     }


### PR DESCRIPTION
Uninstalling apps from launcher on ZUX OS 2.0/1.5 uses the `deletePackageVersioned` API, but the API is not the first among APIs with the same name in the framework. So the hook fails because it only take the first method of all matching methods for hooking.

This PR adds a new field `hookAll` in the code generator, which should call the `MutableList<Unhook>.hookAndAddAll` extension. This will hook all matching methods, and I can confirm it works well on ZUX OS 2.0 (Lenovo Y700 gen5) and ZUX OS 1.5 (Lenovo XiaoXin Pro GT 11).

在ZUX OS 2.0/1.5版本中卸载app时会调用`deletePackageVersioned` API，但在该系统的framework中，调用的这个API并不是所有同名函数的第一个。因为原本的hook只针对找到的第一个函数，所以hook不生效。

这个PR在代码生成器中新增了一个`hookAll`字段，生成的代码将会调用`MutableList<Unhook>.hookAndAddAll`扩展函数，把所有同名函数都hook上。实测在ZUX OS 2.0（联想拯救者Y700 第五代）和ZUX OS 1.5（联想小新平板Pro GT 11）中hook生效并修复了bug。